### PR TITLE
Fix dependency issue caused by fsspec

### DIFF
--- a/generate_data.py
+++ b/generate_data.py
@@ -85,7 +85,7 @@ def main():
         os.makedirs(data_path, exist_ok=True)
         processed_data = {}
         for split in args.split_list:
-            dataset = load_dataset('lex_glue', data, split=split)
+            dataset = load_dataset('coastalcph/lex_glue', data, split=split, trust_remote_code=True)
             texts = get_texts(data, dataset, hier=args.format == 'hier')
             labels = get_labels(data, dataset, data2task(data))
             assert len(texts) == len(labels)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-datasets==2.5.2
+datasets==2.18.0 # or any version > 2.15.0
 nltk==3.7
 pandas==1.5.0
 PyYAML==6.0


### PR DESCRIPTION
**Description**:  An error occurs while running ``bash generate_data.sh``, caused by a dependency issue caused by fsspec. Update `datasets` version to 2.18.0 and update API can resolve the issue.
```
Traceback (most recent call last):
  File "generate_data.py", line 115, in <module>
    main()
  File "generate_data.py", line 88, in main
    dataset = load_dataset('lex_glue', data, split=split)
  File "/home/eleven/miniconda3/envs/baseline/lib/python3.8/site-packages/datasets/load.py", line 1670, in load_dataset
    builder_instance = load_dataset_builder(
  File "/home/eleven/miniconda3/envs/baseline/lib/python3.8/site-packages/datasets/load.py", line 1447, in load_dataset_builder
    dataset_module = dataset_module_factory(
  File "/home/eleven/miniconda3/envs/baseline/lib/python3.8/site-packages/datasets/load.py", line 1172, in dataset_module_factory
    raise e1 from None
  File "/home/eleven/miniconda3/envs/baseline/lib/python3.8/site-packages/datasets/load.py", line 1151, in dataset_module_factory
    return HubDatasetModuleFactoryWithoutScript(
  File "/home/eleven/miniconda3/envs/baseline/lib/python3.8/site-packages/datasets/load.py", line 744, in __init__
    assert self.name.count("/") == 1
AssertionError
```

